### PR TITLE
Improve availability of service on cold start

### DIFF
--- a/src/api/stats/getAmmPrices.ts
+++ b/src/api/stats/getAmmPrices.ts
@@ -5,15 +5,12 @@ import { fetchAmmPrices } from '../../utils/fetchAmmPrices';
 import omnidexPools from '../../data/telos/omnidexLpPools.json';
 import zappyPools from '../../data/telos/zappyLpPools.json';
 
-const INIT_DELAY = 0 * 60 * 1000;
+const INIT_DELAY = 0;
 const REFRESH_INTERVAL = 5 * 60 * 1000;
 
 // FIXME: if this list grows too big we might hit the ratelimit on initialization everytime
 // Implement in case of emergency
-const pools = [
-  ...omnidexPools, 
-  ...zappyPools
-];
+const pools = [...omnidexPools, ...zappyPools];
 
 const knownPrices = {
   USDT: 1,

--- a/src/api/stats/telos/index.js
+++ b/src/api/stats/telos/index.js
@@ -1,10 +1,7 @@
 const getOmnidexLpApys = require('./getOmnidexLpApys');
 const getZappyLpApys = require('./getZappyLpApys');
 
-const getApys = [
-  getOmnidexLpApys, 
-  getZappyLpApys
-];
+const getApys = [getOmnidexLpApys, getZappyLpApys];
 
 const getTelosApys = async () => {
   let apys = {};


### PR DESCRIPTION
Fixes sporadic 500 errors seen in production.

- Adds a consistent way to lazily load into the cache. 
- Sets the initialization delay to 0 seconds to avoid slowness on cold starts. This may be updated in the future if rate limits become problematic.