### PR TITLE
Do not overwrite caches when refresh fails

### DIFF
--- a/src/api/stats/getChainTvl.js
+++ b/src/api/stats/getChainTvl.js
@@ -64,6 +64,4 @@ const getVaultBalances = async (chainId, vaults) => {
   return res[0].map(v => new BigNumber(v.balance));
 };
 
-
-
 module.exports = getChainTvl;

--- a/src/utils/fetchAmmPrices.js
+++ b/src/utils/fetchAmmPrices.js
@@ -63,7 +63,7 @@ const fetchAmmPrices = async (pools, knownPrices) => {
       } catch (e) {
         console.error('fetchAmmPrices', e);
       }
-      
+
       // Merge fetched data
       for (let j = 0; j < batch.length; j++) {
         filtered[j + i].totalSupply = new BigNumber(buf[j * 3 + 0]?.toString());


### PR DESCRIPTION
This change allows us to better handle failures in downstreams.