### PR TITLE
Fix native and wrapped TLOS mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "eslint": "^8.12.0",
     "eslint-config-prettier": "^8.5.0",
     "husky": "^7.0.4",
-    "lint-staged": "^12.3.7",
+    "lint-staged": "^12.4.1",
     "nodemon": "^2.0.6",
     "nyc": "^15.1.0",
     "prettier": "^2.3.2",

--- a/packages/address-book/address-book/telos/tokens/tokens.ts
+++ b/packages/address-book/address-book/telos/tokens/tokens.ts
@@ -11,15 +11,8 @@ const TLOS = {
 } as const;
 
 const _tokens = {
-  WTLOS: {
-    chainId: 40,
-    address: '0xD102cE6A4dB07D247fcc28F366A623Df0938CA9E',
-    symbol: 'WTLOS',
-    name: 'Wrapped TLOS',
-    logoURI:
-      'https://raw.githubusercontent.com/telosnetwork/images/master/logos_2021/Symbol%202.svg',
-    decimals: 18,
-  },
+  TLOS: TLOS,
+  WTLOS: TLOS,
   WBTC: {
     name: 'Wrapped BTC',
     symbol: 'WBTC',

--- a/packages/address-book/package.json
+++ b/packages/address-book/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yieldhubfinance/blockchain-addressbook",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A collection of useful addresses on various chains for defi development",
   "main": "build/address-book/index.js",
   "types": "build/address-book/index.d.ts",


### PR DESCRIPTION
in all other address books, the native coin maps to the wrapped version.